### PR TITLE
Combined dependency updates (2023-04-02)

### DIFF
--- a/net/Portable/Portable.csproj
+++ b/net/Portable/Portable.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.1.2" />
+    <PackageReference Include="NLog" Version="5.1.3" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump NLog from 5.1.2 to 5.1.3 in /net](https://github.com/javiertuya/portable/pull/1)