### PR TITLE
Combined dependency updates (2023-05-01)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -45,7 +45,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/net/Portable/Portable.csproj
+++ b/net/Portable/Portable.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.1.3" />
+    <PackageReference Include="NLog" Version="5.1.4" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump maven-surefire-report-plugin from 2.22.2 to 3.0.0 in /java](https://github.com/javiertuya/portable/pull/5)
- [Bump NLog from 5.1.3 to 5.1.4 in /net](https://github.com/javiertuya/portable/pull/4)