### PR TITLE
Combined dependency updates (2023-09-02)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -115,7 +115,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant-junit</artifactId>
-						<version>1.10.13</version>
+						<version>1.10.14</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.ant</groupId>

--- a/net/Portable/Portable.csproj
+++ b/net/Portable/Portable.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.2.2" />
+    <PackageReference Include="NLog" Version="5.2.3" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/net/PortableTest/PortableTest.csproj
+++ b/net/PortableTest/PortableTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     
     <PackageReference Include="NUnit" Version="3.13.3" />
     


### PR DESCRIPTION
Includes these updates:
- [Bump org.apache.ant:ant-junit from 1.10.13 to 1.10.14 in /java](https://github.com/javiertuya/portable/pull/32)
- [Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.2 in /net](https://github.com/javiertuya/portable/pull/31)
- [Bump NLog from 5.2.2 to 5.2.3 in /net](https://github.com/javiertuya/portable/pull/30)