### PR TITLE
Combined dependency updates (2023-10-03)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       #https://stackoverflow.com/questions/61096521/how-to-use-gpg-key-in-github-actions
       #It requires export the private key with the armor option: gpg --output private.pgm --armor --export-secret-key <email>
       - name: Import GPG Key 
-        uses: crazy-max/ghaction-import-gpg@v5.3.0
+        uses: crazy-max/ghaction-import-gpg@v6.0.0
         with:
           gpg_private_key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       #Official documentation seems incomplete. To avoid failure when importing key: 
       #https://stackoverflow.com/questions/61096521/how-to-use-gpg-key-in-github-actions
       #It requires export the private key with the armor option: gpg --output private.pgm --armor --export-secret-key <email>
@@ -50,7 +50,7 @@ jobs:
       contents: read
       packages: write 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v3.2.0
         with:
             dotnet-version: '6.0.x'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     #if: ${{ false }}  # disable for now
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Select Java Version
         uses: actions/setup-java@v3
         with:
@@ -60,7 +60,7 @@ jobs:
       contents: read
       checks: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v3.2.0
         with:
             dotnet-version: '3.1.x'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v3.8.0
+        uses: mikepenz/action-junit-report@v4.0.1
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.13.0</version>
+			<version>2.14.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -72,7 +72,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.5.0</version>
+				<version>3.6.0</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/net/Portable/Portable.csproj
+++ b/net/Portable/Portable.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.2.3" />
+    <PackageReference Include="NLog" Version="5.2.4" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/checkout from 3 to 4](https://github.com/javiertuya/portable/pull/34)
- [Bump crazy-max/ghaction-import-gpg from 5.3.0 to 6.0.0](https://github.com/javiertuya/portable/pull/35)
- [Bump mikepenz/action-junit-report from 3.8.0 to 4.0.1](https://github.com/javiertuya/portable/pull/36)
- [Bump commons-io:commons-io from 2.13.0 to 2.14.0 in /java](https://github.com/javiertuya/portable/pull/37)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.5.0 to 3.6.0 in /java](https://github.com/javiertuya/portable/pull/38)
- [Bump NLog from 5.2.3 to 5.2.4 in /net](https://github.com/javiertuya/portable/pull/39)