### PR TITLE
Combined dependency updates (2024-01-03)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       #https://stackoverflow.com/questions/61096521/how-to-use-gpg-key-in-github-actions
       #It requires export the private key with the armor option: gpg --output private.pgm --armor --export-secret-key <email>
       - name: Import GPG Key 
-        uses: crazy-max/ghaction-import-gpg@v6.0.0
+        uses: crazy-max/ghaction-import-gpg@v6.1.0
         with:
           gpg_private_key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v3.2.0
+      - uses: actions/setup-dotnet@v4.0.0
         with:
             dotnet-version: '6.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
  
       - if: always()
         name: Publish test reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-report-java-files
           #working-directory does not work here
@@ -86,7 +86,7 @@ jobs:
 
       - if: always()
         name: Publish test reports files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-report-net-files
           #working-directory does not work here

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v3.2.0
+      - uses: actions/setup-dotnet@v4.0.0
         with:
             dotnet-version: '3.1.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
       run:
         working-directory: java
     steps:
-      - uses: javiertuya/branch-snapshots-action@v1.2.0
+      - uses: javiertuya/branch-snapshots-action@v1.2.1
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: java

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -45,7 +45,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.2.2</version>
+				<version>3.2.3</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -72,7 +72,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.6.2</version>
+				<version>3.6.3</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/net/Portable/Portable.csproj
+++ b/net/Portable/Portable.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.2.7" />
+    <PackageReference Include="NLog" Version="5.2.8" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/net/PortableTest/PortableTest.csproj
+++ b/net/PortableTest/PortableTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     
-    <PackageReference Include="NUnit" Version="4.0.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/setup-dotnet from 3.2.0 to 4.0.0](https://github.com/javiertuya/portable/pull/59)
- [Bump actions/upload-artifact from 3 to 4](https://github.com/javiertuya/portable/pull/57)
- [Bump crazy-max/ghaction-import-gpg from 6.0.0 to 6.1.0](https://github.com/javiertuya/portable/pull/56)
- [Bump javiertuya/branch-snapshots-action from 1.2.0 to 1.2.1](https://github.com/javiertuya/portable/pull/58)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.6.2 to 3.6.3 in /java](https://github.com/javiertuya/portable/pull/54)
- [Bump org.apache.maven.plugins:maven-surefire-report-plugin from 3.2.2 to 3.2.3 in /java](https://github.com/javiertuya/portable/pull/55)
- [Bump NLog from 5.2.7 to 5.2.8 in /net](https://github.com/javiertuya/portable/pull/61)
- [Bump NUnit from 4.0.0 to 4.0.1 in /net](https://github.com/javiertuya/portable/pull/60)