### PR TITLE
Combined dependency updates (2024-03-03)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.16.0</version>
+			<version>1.16.1</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/net/PortableTest/PortableTest.csproj
+++ b/net/PortableTest/PortableTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     
     <PackageReference Include="NUnit" Version="4.0.1" />
     

--- a/net/PortableTest/PortableTest.csproj
+++ b/net/PortableTest/PortableTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     
-    <PackageReference Include="NUnit" Version="4.0.1" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Combined update created by [DashGit](https://github.com/javiertuya/dashgit). Includes these updates:
- [Bump Microsoft.NET.Test.Sdk from 17.8.0 to 17.9.0 in /net](https://github.com/javiertuya/portable/pull/68)
- [Bump NUnit from 4.0.1 to 4.1.0 in /net](https://github.com/javiertuya/portable/pull/67)
- [Bump commons-codec:commons-codec from 1.16.0 to 1.16.1 in /java](https://github.com/javiertuya/portable/pull/66)