### PR TITLE
Combined dependency updates (2024-04-01)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v4.1.0
+        uses: mikepenz/action-junit-report@v4.2.1
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
       run:
         working-directory: java
     steps:
-      - uses: javiertuya/branch-snapshots-action@v1.2.1
+      - uses: javiertuya/branch-snapshots-action@v1.2.2
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: java

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -156,7 +156,7 @@
                     <plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.1.0</version>
+						<version>3.2.2</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.15.1</version>
+			<version>2.16.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.1.0 to 3.2.2 in /java](https://github.com/javiertuya/portable/pull/73)
- [Bump commons-io:commons-io from 2.15.1 to 2.16.0 in /java](https://github.com/javiertuya/portable/pull/72)
- [Bump mikepenz/action-junit-report from 4.1.0 to 4.2.1](https://github.com/javiertuya/portable/pull/71)
- [Bump javiertuya/branch-snapshots-action from 1.2.1 to 1.2.2](https://github.com/javiertuya/portable/pull/70)