### PR TITLE
Combined dependency updates (2024-05-01)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
       run:
         working-directory: java
     steps:
-      - uses: javiertuya/branch-snapshots-action@v1.2.2
+      - uses: javiertuya/branch-snapshots-action@v1.2.3
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: java

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -59,7 +59,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.16.0</version>
+			<version>2.16.1</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.16.1</version>
+			<version>1.17.0</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -156,7 +156,7 @@
                     <plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.2</version>
+						<version>3.2.4</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/net/Portable/Portable.csproj
+++ b/net/Portable/Portable.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.2.8" />
+    <PackageReference Include="NLog" Version="5.3.2" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-source-plugin from 3.3.0 to 3.3.1 in /java](https://github.com/javiertuya/portable/pull/80)
- [Bump commons-codec:commons-codec from 1.16.1 to 1.17.0 in /java](https://github.com/javiertuya/portable/pull/79)
- [Bump commons-io:commons-io from 2.16.0 to 2.16.1 in /java](https://github.com/javiertuya/portable/pull/78)
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.2 to 3.2.4 in /java](https://github.com/javiertuya/portable/pull/77)
- [Bump NLog from 5.2.8 to 5.3.2 in /net](https://github.com/javiertuya/portable/pull/76)
- [Bump javiertuya/branch-snapshots-action from 1.2.2 to 1.2.3](https://github.com/javiertuya/portable/pull/75)