### PR TITLE
Combined dependency updates (2024-08-03)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4.0.0
+      - uses: actions/setup-dotnet@v4.0.1
         with:
             dotnet-version: '6.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4.0.0
+      - uses: actions/setup-dotnet@v4.0.1
         with:
             dotnet-version: '3.1.x'
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -72,7 +72,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.8.0</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -45,7 +45,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.17.0</version>
+			<version>1.17.1</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/net/PortableTest/PortableTest.csproj
+++ b/net/PortableTest/PortableTest.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit" Version="4.1.0" />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-surefire-report-plugin from 3.3.0 to 3.3.1 in /java](https://github.com/javiertuya/portable/pull/94)
- [Bump commons-codec:commons-codec from 1.17.0 to 1.17.1 in /java](https://github.com/javiertuya/portable/pull/93)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.7.0 to 3.8.0 in /java](https://github.com/javiertuya/portable/pull/92)
- [Bump actions/setup-dotnet from 4.0.0 to 4.0.1](https://github.com/javiertuya/portable/pull/91)
- [Bump NUnit3TestAdapter from 4.5.0 to 4.6.0 in /net](https://github.com/javiertuya/portable/pull/90)