### PR TITLE
Combined dependency updates (2024-09-02)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -45,7 +45,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.3.1</version>
+				<version>3.5.0</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -72,7 +72,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.8.0</version>
+				<version>3.10.0</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -115,7 +115,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant-junit</artifactId>
-						<version>1.10.14</version>
+						<version>1.10.15</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.ant</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -156,7 +156,7 @@
                     <plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.4</version>
+						<version>3.2.5</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/net/Portable/Portable.csproj
+++ b/net/Portable/Portable.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.3.2" />
+    <PackageReference Include="NLog" Version="5.3.3" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/net/PortableTest/PortableTest.csproj
+++ b/net/PortableTest/PortableTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     
-    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>

--- a/net/PortableTest/PortableTest.csproj
+++ b/net/PortableTest/PortableTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     
     <PackageReference Include="NUnit" Version="4.2.2" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NUnit from 4.1.0 to 4.2.2 in /net](https://github.com/javiertuya/portable/pull/102)
- [Bump Microsoft.NET.Test.Sdk from 17.10.0 to 17.11.0 in /net](https://github.com/javiertuya/portable/pull/101)
- [Bump NLog from 5.3.2 to 5.3.3 in /net](https://github.com/javiertuya/portable/pull/100)
- [Bump org.apache.maven.plugins:maven-surefire-report-plugin from 3.3.1 to 3.5.0 in /java](https://github.com/javiertuya/portable/pull/99)
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.4 to 3.2.5 in /java](https://github.com/javiertuya/portable/pull/98)
- [Bump org.apache.ant:ant-junit from 1.10.14 to 1.10.15 in /java](https://github.com/javiertuya/portable/pull/97)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.8.0 to 3.10.0 in /java](https://github.com/javiertuya/portable/pull/96)