### PR TITLE
Combined dependency updates (2024-10-02)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -156,7 +156,7 @@
                     <plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.5</version>
+						<version>3.2.7</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.16.1</version>
+			<version>2.17.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -72,7 +72,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.10.0</version>
+				<version>3.10.1</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/net/Portable/Portable.csproj
+++ b/net/Portable/Portable.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.3.3" />
+    <PackageReference Include="NLog" Version="5.3.4" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/net/PortableTest/PortableTest.csproj
+++ b/net/PortableTest/PortableTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     
     <PackageReference Include="NUnit" Version="4.2.2" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NLog from 5.3.3 to 5.3.4 in /net](https://github.com/javiertuya/portable/pull/108)
- [Bump Microsoft.NET.Test.Sdk from 17.11.0 to 17.11.1 in /net](https://github.com/javiertuya/portable/pull/107)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.10.0 to 3.10.1 in /java](https://github.com/javiertuya/portable/pull/106)
- [Bump commons-io:commons-io from 2.16.1 to 2.17.0 in /java](https://github.com/javiertuya/portable/pull/105)
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.5 to 3.2.7 in /java](https://github.com/javiertuya/portable/pull/104)