### PR TITLE
Combined dependency updates (2025-03-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v5.3.0
+        uses: mikepenz/action-junit-report@v5.4.0
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/net/Portable/Portable.csproj
+++ b/net/Portable/Portable.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.3.4" />
+    <PackageReference Include="NLog" Version="5.4.0" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/net/PortableTest/PortableTest.csproj
+++ b/net/PortableTest/PortableTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     
     <PackageReference Include="NUnit" Version="4.3.2" />
     

--- a/net/PortableTest/PortableTest.csproj
+++ b/net/PortableTest/PortableTest.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit" Version="4.3.2" />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NLog from 5.3.4 to 5.4.0 in /net](https://github.com/javiertuya/portable/pull/132)
- [Bump Microsoft.NET.Test.Sdk from 17.12.0 to 17.13.0 in /net](https://github.com/javiertuya/portable/pull/131)
- [Bump NUnit3TestAdapter from 4.6.0 to 5.0.0 in /net](https://github.com/javiertuya/portable/pull/130)
- [Bump mikepenz/action-junit-report from 5.3.0 to 5.4.0](https://github.com/javiertuya/portable/pull/129)