### PR TITLE
Combined dependency updates (2025-08-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v5.6.1
+        uses: mikepenz/action-junit-report@v5.6.2
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -156,7 +156,7 @@
                     <plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.7</version>
+						<version>3.2.8</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.19.0</version>
+			<version>2.20.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.18.0</version>
+			<version>1.19.0</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/net/Portable/Portable.csproj
+++ b/net/Portable/Portable.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="6.0.1" />
+    <PackageReference Include="NLog" Version="6.0.2" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump commons-io:commons-io from 2.19.0 to 2.20.0 in /java](https://github.com/javiertuya/portable/pull/152)
- [Bump commons-codec:commons-codec from 1.18.0 to 1.19.0 in /java](https://github.com/javiertuya/portable/pull/151)
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.7 to 3.2.8 in /java](https://github.com/javiertuya/portable/pull/150)
- [Bump mikepenz/action-junit-report from 5.6.1 to 5.6.2](https://github.com/javiertuya/portable/pull/149)
- [Bump NLog from 6.0.1 to 6.0.2](https://github.com/javiertuya/portable/pull/148)