### PR TITLE
Combined dependency updates (2025-10-04)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-dotnet@v4.3.1
+      - uses: actions/setup-dotnet@v5.0.0
         with:
             dotnet-version: '6.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
       packages: read
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-dotnet@v4.3.1
+      - uses: actions/setup-dotnet@v5.0.0
         with:
             dotnet-version: '8.0.x'
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -45,7 +45,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.5.3</version>
+				<version>3.5.4</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -145,7 +145,7 @@
 					<plugin>
 						<groupId>org.sonatype.central</groupId>
 						<artifactId>central-publishing-maven-plugin</artifactId>
-						<version>0.8.0</version>
+						<version>0.9.0</version>
 						<extensions>true</extensions>
 						<configuration>
 							<publishingServerId>central</publishingServerId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -72,7 +72,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.11.3</version>
+				<version>3.12.0</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/net/Portable/Portable.csproj
+++ b/net/Portable/Portable.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="6.0.3" />
+    <PackageReference Include="NLog" Version="6.0.4" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/net/Portable/Portable.csproj
+++ b/net/Portable/Portable.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="NLog" Version="6.0.4" />
 
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NLog from 6.0.3 to 6.0.4](https://github.com/javiertuya/portable/pull/166)
- [Bump Newtonsoft.Json from 13.0.3 to 13.0.4](https://github.com/javiertuya/portable/pull/165)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.11.3 to 3.12.0 in /java](https://github.com/javiertuya/portable/pull/164)
- [Bump org.sonatype.central:central-publishing-maven-plugin from 0.8.0 to 0.9.0 in /java](https://github.com/javiertuya/portable/pull/163)
- [Bump org.apache.maven.plugins:maven-surefire-report-plugin from 3.5.3 to 3.5.4 in /java](https://github.com/javiertuya/portable/pull/162)
- [Bump actions/setup-dotnet from 4.3.1 to 5.0.0](https://github.com/javiertuya/portable/pull/161)