### PR TITLE
Combined dependency updates (2026-05-02)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.21.0</version>
+			<version>1.22.0</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -115,7 +115,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant-junit</artifactId>
-						<version>1.10.16</version>
+						<version>1.10.17</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.ant</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.21.0</version>
+			<version>2.22.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>

--- a/net/PortableTest/PortableTest.csproj
+++ b/net/PortableTest/PortableTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     
     <PackageReference Include="NUnit" Version="4.5.1" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Microsoft.NET.Test.Sdk from 18.3.0 to 18.5.1](https://github.com/javiertuya/portable/pull/216)
- [Bump commons-io:commons-io from 2.21.0 to 2.22.0 in /java](https://github.com/javiertuya/portable/pull/215)
- [Bump org.apache.ant:ant-junit from 1.10.16 to 1.10.17 in /java](https://github.com/javiertuya/portable/pull/214)
- [Bump commons-codec:commons-codec from 1.21.0 to 1.22.0 in /java](https://github.com/javiertuya/portable/pull/213)