### PR TITLE
Combined dependency updates (2026-06-02)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-dotnet@v5.2.0
+      - uses: actions/setup-dotnet@v5.3.0
         with:
             dotnet-version: '10.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       
-      - uses: actions/setup-dotnet@v5.2.0
+      - uses: actions/setup-dotnet@v5.3.0
         with:
             dotnet-version: '10.0.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.0
+        uses: mikepenz/action-junit-report@v6.4.1
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -45,7 +45,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.5.5</version>
+				<version>3.5.6</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/net/Portable/Portable.csproj
+++ b/net/Portable/Portable.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="6.1.2" />
+    <PackageReference Include="NLog" Version="6.1.3" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>

--- a/net/PortableTest/PortableTest.csproj
+++ b/net/PortableTest/PortableTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     
-    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>

--- a/net/PortableTest/PortableTest.csproj
+++ b/net/PortableTest/PortableTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     
     <PackageReference Include="NUnit" Version="4.5.1" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NUnit from 4.5.1 to 4.6.1](https://github.com/javiertuya/portable/pull/223)
- [Bump NLog from 6.1.2 to 6.1.3](https://github.com/javiertuya/portable/pull/222)
- [Bump Microsoft.NET.Test.Sdk from 18.5.1 to 18.6.0](https://github.com/javiertuya/portable/pull/221)
- [Bump actions/setup-dotnet from 5.2.0 to 5.3.0](https://github.com/javiertuya/portable/pull/220)
- [Bump mikepenz/action-junit-report from 6.4.0 to 6.4.1](https://github.com/javiertuya/portable/pull/219)
- [Bump org.apache.maven.plugins:maven-surefire-report-plugin from 3.5.5 to 3.5.6 in /java](https://github.com/javiertuya/portable/pull/218)